### PR TITLE
Optimize animations

### DIFF
--- a/hardhat-project/contracts/SVG.sol
+++ b/hardhat-project/contracts/SVG.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.2;
+pragma solidity 0.8.12;
 
 import "hardhat/console.sol";
 
@@ -82,12 +82,15 @@ library SVG {
 
         // Refs start always at the first frame that is required to be present
         bytes memory frameRefs = "%2523f0";
-        for (uint256 f = 1; f < framesCount; f++) {
+        for (uint256 f = 1; f < framesCount;) {
             frameRefs = abi.encodePacked(
                 frameRefs,
                 "%253B%2523f",
                 HEX_CHARS[f]
             );
+            unchecked {
+              f++;
+            }
         }
 
         // If the loop style is ping-pong, add all the frames in reverse order
@@ -95,12 +98,15 @@ library SVG {
         // Note: SVG doesn't support this animation style yet, see
         // https://github.com/w3c/svgwg/issues/130
         if (isPingPongLoopStyle) {
-            for (uint256 f = framesCount - 2; f >= 0; f--) {
+            for (uint256 f = framesCount - 2; f >= 0;) {
                 frameRefs = abi.encodePacked(
                     frameRefs,
                     "%253B%2523f",
                     HEX_CHARS[f]
                 );
+                unchecked {
+                  f--;
+                }
             }
         }
 
@@ -298,7 +304,7 @@ library SVG {
         // Offset for storing data in the defs bytes
         uint256 defsOffset = 0;
 
-        for (uint256 f = 0; f < framesCount; f++) {
+        for (uint256 f = 0; f < framesCount;) {
             bytes memory bitmap = _encodeBitmap(data, frameDataOffset);
 
             assembly {
@@ -414,8 +420,11 @@ library SVG {
                 mstore(defsPtr, "%253C%252Fg%253E")
             }
 
-            frameDataOffset += 141;
-            defsOffset += defLength;
+            unchecked {
+              frameDataOffset += 141;
+              defsOffset += defLength;
+              f++;
+            }
         }
     }
 
@@ -432,7 +441,7 @@ library SVG {
         colorTable = new bytes(COLORS_NUMBER * 4);
         // Skip the first byte that contains packed fields
         dataOffset++;
-        for (uint256 i = 0; i < 4; i++) {
+        for (uint256 i = 0; i < 4;) {
             bytes3 colorsPack = bytes3(data[dataOffset]) |
                 (bytes3(data[dataOffset + 1]) >> 8) |
                 (bytes3(data[dataOffset + 2]) >> 16);
@@ -445,7 +454,7 @@ library SVG {
             // 2. colorsPack >> 12 & 0x3f
             // 3. colorsPack >> 6 & 0x3f
             // 4. colorsPack & 0x3f
-            for (uint256 j = 0; j < 4; j++) {
+            for (uint256 j = 0; j < 4;) {
                 // jth color in the 4 colors pack
                 bytes3 color = _encode24BitColor(
                     bytes1((colorsPack >> (6 * (3 - j))) << 16) & 0x3f
@@ -463,9 +472,15 @@ library SVG {
                 } else {
                     colorTable[colorIndex + 3] = 0xff;
                 }
+                unchecked {
+                  j++;
+                }
             }
 
-            dataOffset += 3;
+            unchecked {
+              dataOffset += 3;
+              i++;
+            }
         }
     }
 

--- a/hardhat-project/contracts/StunningPotato.sol
+++ b/hardhat-project/contracts/StunningPotato.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.2;
+pragma solidity 0.8.12;
 
 import "hardhat/console.sol";
 
@@ -172,7 +172,7 @@ contract StunningPotato is
 
         uint256 newFramesCount = 0;
         uint256 offset = APPLICATION_DATA_HEADER_SIZE;
-        for (uint256 i = 0; i < framesCount; i++) {
+        for (uint256 i = 0; i < framesCount;) {
             bytes calldata frameData = data[offset:offset + FRAME_DATA_SIZE];
 
             uint256 frameId = uint256(keccak256(frameData));
@@ -192,7 +192,10 @@ contract StunningPotato is
                 mstore(storageDataPtr, frameId)
             }
 
-            offset += FRAME_DATA_SIZE;
+            unchecked {
+              offset += FRAME_DATA_SIZE;
+              i++;
+            }
         }
 
         uint256 totalPrice = PRICE_ANIMATION + newFramesCount * PRICE_FRAME;
@@ -344,7 +347,7 @@ contract StunningPotato is
             );
             animationData[0] = data[0];
             animationData[1] = data[1];
-            for (uint256 i = 0; i < framesCount; i++) {
+            for (uint256 i = 0; i < framesCount;) {
                 bytes32 rawFrameId;
                 assembly {
                     rawFrameId := mload(add(add(data, 34), mul(i, 32)))
@@ -375,6 +378,9 @@ contract StunningPotato is
                             mload(add(frameDataPtr, j))
                         )
                     }
+                }
+                unchecked {
+                  i++;
                 }
             }
             imageData = SVG.encodeAnimation(animationData);

--- a/hardhat-project/contracts/StunningPotato.sol
+++ b/hardhat-project/contracts/StunningPotato.sol
@@ -151,10 +151,8 @@ contract StunningPotato is
         external
         payable
     {
-        // TODO: Optimize - Remove variable
-        uint256 packedFields = uint8(data[0]);
-        uint256 framesCount = (packedFields >> 4) + 1;
-        uint256 newFramesCount = 0;
+        // Extract frames count from the packed fields
+        uint256 framesCount = (uint8(data[0]) >> 4) + 1;
         _validateAnimationData(data, framesCount);
 
         // Encode animation storage data
@@ -172,8 +170,9 @@ contract StunningPotato is
         storageData[0] = data[0];
         storageData[1] = data[1];
 
+        uint256 newFramesCount = 0;
+        uint256 offset = APPLICATION_DATA_HEADER_SIZE;
         for (uint256 i = 0; i < framesCount; i++) {
-            uint256 offset = APPLICATION_DATA_HEADER_SIZE + i * FRAME_DATA_SIZE;
             bytes calldata frameData = data[offset:offset + FRAME_DATA_SIZE];
 
             uint256 frameId = uint256(keccak256(frameData));
@@ -192,6 +191,8 @@ contract StunningPotato is
                 )
                 mstore(storageDataPtr, frameId)
             }
+
+            offset += FRAME_DATA_SIZE;
         }
 
         uint256 totalPrice = PRICE_ANIMATION + newFramesCount * PRICE_FRAME;

--- a/hardhat-project/contracts/StunningPotato.sol
+++ b/hardhat-project/contracts/StunningPotato.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.2;
 
+import "hardhat/console.sol";
+
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import "@openzeppelin/contracts/interfaces/IERC2981.sol";
@@ -123,7 +125,7 @@ contract StunningPotato is
         returns (uint256 tokenId)
     {
         _validateFrameData(data);
-        tokenId = _createResource(author, data, ResourceType.Frame);
+        tokenId = _createResource(author, Resource(ResourceType.Frame, data));
     }
 
     /**
@@ -149,27 +151,53 @@ contract StunningPotato is
         external
         payable
     {
+        // TODO: Optimize - Remove variable
         uint256 packedFields = uint8(data[0]);
         uint256 framesCount = (packedFields >> 4) + 1;
         uint256 newFramesCount = 0;
         _validateAnimationData(data, framesCount);
 
+        // Encode animation storage data
+        //
+        // Animation storage data format is different from the input animation
+        // data format. The difference is that instead of storing the raw data
+        // of each frame, the storage animation data stores just frame ids.
+        //
+        // The trade off is some time spent to compute the new format in
+        // exchange for 141 - 32 = 109 spared bytes per frame.
+        bytes memory storageData = new bytes(
+            APPLICATION_DATA_HEADER_SIZE + 32 * framesCount
+        );
+        // Copy header data
+        storageData[0] = data[0];
+        storageData[1] = data[1];
+
         for (uint256 i = 0; i < framesCount; i++) {
             uint256 offset = APPLICATION_DATA_HEADER_SIZE + i * FRAME_DATA_SIZE;
             bytes calldata frameData = data[offset:offset + FRAME_DATA_SIZE];
-            // TODO: Use this value to build a list of frame references
+
             uint256 frameId = uint256(keccak256(frameData));
+
+            // Create a new frame if it doesn't exist already
             if (!_exists(frameId)) {
                 newFramesCount++;
                 _createFrame(author, frameData);
+            }
+
+            // Store the frame reference in the animation storage data
+            assembly {
+                let storageDataPtr := add(
+                    storageData,
+                    add(32, add(APPLICATION_DATA_HEADER_SIZE, mul(i, 32)))
+                )
+                mstore(storageDataPtr, frameId)
             }
         }
 
         uint256 totalPrice = PRICE_ANIMATION + newFramesCount * PRICE_FRAME;
         require(msg.value >= totalPrice, "E02");
 
-        // TODO: Store a list of frame references instead of raw frame data
-        _createResource(author, data, ResourceType.Animation);
+        _createResource(author, Resource(ResourceType.Animation, storageData));
 
         // Send any excess ETH back to the caller
         uint256 excess = msg.value - totalPrice;
@@ -226,15 +254,14 @@ contract StunningPotato is
      *
      * Data must be validated by the caller.
      */
-    function _createResource(
-        address author,
-        bytes calldata data,
-        ResourceType resourceType
-    ) private returns (uint256 tokenId) {
-        tokenId = uint256(keccak256(data));
+    function _createResource(address author, Resource memory resource)
+        private
+        returns (uint256 tokenId)
+    {
+        tokenId = uint256(keccak256(resource.data));
         _safeMint(author, tokenId);
 
-        _resources[tokenId] = Resource(resourceType, data);
+        _resources[tokenId] = resource;
         _authors[tokenId] = author;
     }
 
@@ -307,7 +334,49 @@ contract StunningPotato is
         if (_resources[tokenId].resourceType == ResourceType.Frame) {
             imageData = SVG.encodeFrame(_resources[tokenId].data);
         } else {
-            imageData = SVG.encodeAnimation(_resources[tokenId].data);
+            // NOTE: Maybe this assignment is redundant and I can access
+            // frame data in Yul directly from the struct
+            bytes memory data = _resources[tokenId].data;
+            uint256 framesCount = (uint8(data[0]) >> 4) + 1;
+            bytes memory animationData = new bytes(
+                APPLICATION_DATA_HEADER_SIZE + FRAME_DATA_SIZE * framesCount
+            );
+            animationData[0] = data[0];
+            animationData[1] = data[1];
+            for (uint256 i = 0; i < framesCount; i++) {
+                bytes32 rawFrameId;
+                assembly {
+                    rawFrameId := mload(add(add(data, 34), mul(i, 32)))
+                }
+                uint256 frameId = uint256(rawFrameId);
+                // NOTE: Maybe this assignment is redundant and I can access
+                // frame data in Yul directly from the struct
+                bytes memory frameData = _resources[frameId].data;
+                assembly {
+                    // Jump over length (32) + frames count (1) + packed fields (1)
+                    let animationDataPtr := add(animationData, 34)
+                    // Jump over length (32)
+                    let frameDataPtr := add(frameData, 32)
+
+                    // Copy until end of the frame data:
+                    //
+                    //   ceil(141 / 32) * 32 = 160
+                    for {
+                        let j := 0
+                    } lt(j, 160) {
+                        j := add(j, 32)
+                    } {
+                        mstore(
+                            add(
+                                add(animationDataPtr, mul(FRAME_DATA_SIZE, i)),
+                                j
+                            ),
+                            mload(add(frameDataPtr, j))
+                        )
+                    }
+                }
+            }
+            imageData = SVG.encodeAnimation(animationData);
         }
 
         metadata = string(

--- a/hardhat-project/hardhat.config.ts
+++ b/hardhat-project/hardhat.config.ts
@@ -25,7 +25,7 @@ task("accounts", "Prints the list of accounts", async (taskArgs, hre) => {
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: "0.8.4",
+    version: "0.8.12",
     settings: {
       optimizer: {
         enabled: true,

--- a/hardhat-project/test/index.ts
+++ b/hardhat-project/test/index.ts
@@ -4,6 +4,12 @@ import { ethers } from "hardhat";
 import { StunningPotato } from "../typechain";
 import { JSDOM } from "jsdom";
 
+const TEST_GAS_COST = true;
+const GAS_COST_CREATE_FRAME = '313382';
+const GAS_COST_CREATE_FRAME_WITH_TRANSPARENCY = '313394';
+const GAS_COST_CREATE_ANIMATION = '541772';
+const GAS_COST_CREATE_ANIMATION_LARGE = '922375';
+
 function encodeColorTable(...colors: number[]): string {
   return [0, 4, 8, 12].reduce(
     (res, offset) =>
@@ -158,12 +164,6 @@ describe("StunningPotato", function () {
 
   const PRICE_FRAME = ethers.utils.parseEther("0.01");
   const PRICE_ANIMATION = ethers.utils.parseEther("0.01");
-
-  const TEST_GAS_COST = false;
-  const GAS_COST_CREATE_FRAME = '313382';
-  const GAS_COST_CREATE_FRAME_WITH_TRANSPARENCY = '313394';
-  const GAS_COST_CREATE_ANIMATION = '440604';
-  const GAS_COST_CREATE_ANIMATION_LARGE = '796187';
 
   // `beforeEach` will run before each test, re-deploying the contract every
   // time. It receives a callback, which can be async.

--- a/hardhat-project/test/index.ts
+++ b/hardhat-project/test/index.ts
@@ -17,6 +17,136 @@ function encodeColorTable(...colors: number[]): string {
   )
 }
 
+/**
+ * A valid image should have exactly 256 pixels (rects) and it should have the
+ * expected number of rects for each colors in the input dictionary.
+ */
+function expectValidBitmap(
+  imageDoc: Document | Element,
+  colors: { [key: string]: number }
+) {
+  expect(
+    imageDoc.getElementsByTagNameNS("http://www.w3.org/2000/svg", "rect").length
+  ).to.equal(256);
+
+  for (let color in colors) {
+    expect(
+      imageDoc.querySelectorAll(`rect[fill="${color}"]`).length
+    ).to.equal(colors[color], `Wrong number of rects of color ${color}`)
+  }
+}
+
+
+/**
+ * Parse data URI and performs some trivial check on the frame metadata.
+ *
+ * It expects the image to be composed by a specific number of pixels (rects)
+ * for each input color.
+ */
+function expectValidFrameMetadata(
+  dataURI: string,
+  colors: { [key: string]: number }
+) {
+  // Get data URI content
+  const metadataContent = dataURI.split(",").pop();
+  if (metadataContent == null) {
+    throw "Unexpected empty metadata content";
+  }
+  const metadataDecoded = decodeURIComponent(metadataContent);
+  const metadata = JSON.parse(metadataDecoded);
+  expect(metadata.description).to.equal("Very expensive pixel art animations.");
+  const imageDataURI = metadata.image;
+  // Get data URI content
+  const imageContent = imageDataURI.split(",").pop();
+  if (imageContent == null) {
+    throw "Unexpected empty image content";
+  }
+  const image = decodeURIComponent(imageContent);
+  const imageDoc = new JSDOM(image).window.document;
+  expectValidBitmap(imageDoc, colors);
+}
+
+/**
+ * Parse data URI and performs some trivial check on the animation metadata.
+ *
+ * It expects the animation to define a list of frames. Each frame is should be
+ * composed by a specific number of pixels (rects) for each input color.
+ */
+function expectValidAnimationMetadata(
+  dataURI: string,
+  frames: Array<{ [key: string]: number }>
+) {
+  // Get data URI content
+  const metadataContent = dataURI.split(",").pop();
+  if (metadataContent == null) {
+    throw "Unexpected empty metadata content";
+  }
+  const metadataDecoded = decodeURIComponent(metadataContent);
+  const metadata = JSON.parse(metadataDecoded);
+  expect(metadata.description).to.equal("Very expensive pixel art animations.");
+  const imageDataURI = metadata.image;
+  // Get data URI content
+  const imageContent = imageDataURI.split(",").pop();
+  if (imageContent == null) {
+    throw "Unexpected empty image content";
+  }
+  const image = decodeURIComponent(imageContent);
+  var imageDoc = new JSDOM(image).window.document;
+  frames.forEach((colors, i) => {
+    const frameId = `#f${i.toString(16).toUpperCase()}`;
+    const frame = imageDoc.querySelector(frameId);
+    if (frame == null) {
+      throw `Frame '${frameId}' is missing`;
+    }
+    expectValidBitmap(frame, colors);
+  });
+}
+
+function testFrameData(): string {
+  const packedFields = (0b00000000).toString(16).padStart(2, '0');
+
+  // Color table, EGA default 16 color palette (16 colors * 6 bits)
+  const colorTable = encodeColorTable(
+    0b000000,
+    0b000001,
+    0b000010,
+    0b000011,
+    0b000100,
+    0b000101,
+    0b010100,
+    0b000111,
+    0b111000,
+    0b111001,
+    0b111010,
+    0b111011,
+    0b111100,
+    0b111101,
+    0b111110,
+    0b111111
+  );
+
+  // Bitmap (256 pixels * 4 bits)
+  const bitmap =
+    '0123456789abcdef' +
+    '123456789abcdef0' +
+    '23456789abcdef01' +
+    '3456789abcdef012' +
+    '456789abcdef0123' +
+    '56789abcdef01234' +
+    '6789abcdef012345' +
+    '789abcdef0123456' +
+    '89abcdef01234567' +
+    '9abcdef012345678' +
+    'abcdef0123456789' +
+    'bcdef0123456789a' +
+    'cdef0123456789ab' +
+    'def0123456789abc' +
+    'ef0123456789abcd' +
+    'f0123456789abcde';
+
+  return `0x${packedFields}${colorTable}${bitmap}`;
+}
+
 describe("StunningPotato", function () {
   // A common pattern is to declare some variables, and assign them in the
   // `before` and `beforeEach` callbacks.
@@ -29,10 +159,11 @@ describe("StunningPotato", function () {
   const PRICE_FRAME = ethers.utils.parseEther("0.01");
   const PRICE_ANIMATION = ethers.utils.parseEther("0.01");
 
-  const GAS_COST_CREATE_FRAME = '313498';
-  const GAS_COST_CREATE_FRAME_WITH_TRANSPARENCY = '313510';
-  const GAS_COST_CREATE_ANIMATION = '407412';
-  const GAS_COST_CREATE_ANIMATION_LARGE = '600573';
+  const TEST_GAS_COST = false;
+  const GAS_COST_CREATE_FRAME = '313382';
+  const GAS_COST_CREATE_FRAME_WITH_TRANSPARENCY = '313394';
+  const GAS_COST_CREATE_ANIMATION = '440604';
+  const GAS_COST_CREATE_ANIMATION_LARGE = '796187';
 
   // `beforeEach` will run before each test, re-deploying the contract every
   // time. It receives a callback, which can be async.
@@ -49,45 +180,7 @@ describe("StunningPotato", function () {
   });
 
   it("Should create a new frame", async function () {
-    const packedFields = (0b00000000).toString(16).padStart(2, '0');
-    // Color table, EGA default 16 color palette (16 colors * 6 bits)
-    const colorTable = encodeColorTable(
-      0b000000,
-      0b000001,
-      0b000010,
-      0b000011,
-      0b000100,
-      0b000101,
-      0b010100,
-      0b000111,
-      0b111000,
-      0b111001,
-      0b111010,
-      0b111011,
-      0b111100,
-      0b111101,
-      0b111110,
-      0b111111
-    );
-    // Bitmap (256 pixels * 4 bits)
-    const bitmap =
-      '0123456789abcdef' +
-      '123456789abcdef0' +
-      '23456789abcdef01' +
-      '3456789abcdef012' +
-      '456789abcdef0123' +
-      '56789abcdef01234' +
-      '6789abcdef012345' +
-      '789abcdef0123456' +
-      '89abcdef01234567' +
-      '9abcdef012345678' +
-      'abcdef0123456789' +
-      'bcdef0123456789a' +
-      'cdef0123456789ab' +
-      'def0123456789abc' +
-      'ef0123456789abcd' +
-      'f0123456789abcde';
-    const frameData = `0x${packedFields}${colorTable}${bitmap}`;
+    const frameData = testFrameData();
 
     const createFrameTx = await stunningPotato.createFrame(
       addr1.address,
@@ -97,7 +190,10 @@ describe("StunningPotato", function () {
 
     // wait until the transaction is mined
     const createFrameRx = await createFrameTx.wait();
-    expect(createFrameRx.gasUsed.toString()).to.equal(GAS_COST_CREATE_FRAME);
+
+    if (TEST_GAS_COST) {
+      expect(createFrameRx.gasUsed.toString()).to.equal(GAS_COST_CREATE_FRAME);
+    }
 
     const transfer = (createFrameRx.events ?? []).find(
       event => event.event === "Transfer"
@@ -105,47 +201,26 @@ describe("StunningPotato", function () {
     const { tokenId } = transfer?.args ?? { tokenId: "" };
 
     const metadataDataURI = await stunningPotato.tokenURI(tokenId);
-    // Get data URI content
-    const metadataContent = metadataDataURI.split(",").pop();
-    if (metadataContent == null) {
-      throw "Unexpected empty metadata content";
-    }
-    const metadataDecoded = decodeURIComponent(metadataContent);
-    const metadata = JSON.parse(metadataDecoded);
-    expect(metadata.description).to.equal("Very expensive pixel art animations.");
-    const imageDataURI = metadata.image;
-    // Get data URI content
-    const imageContent = imageDataURI.split(",").pop();
-    if (imageContent == null) {
-      throw "Unexpected empty image content";
-    }
-    const image = decodeURIComponent(imageContent);
-    var imageDoc = new JSDOM(image).window.document;
-    expect(
-      imageDoc.getElementsByTagNameNS("http://www.w3.org/2000/svg", "rect").length
-    ).to.equal(256);
-    const colors = [
-      "#000000FF",
-      "#0000AAFF",
-      "#00AA00FF",
-      "#00AAAAFF",
-      "#AA0000FF",
-      "#AA00AAFF",
-      "#AA5500FF",
-      "#AAAAAAFF",
-      "#555555FF",
-      "#5555FFFF",
-      "#55FF55FF",
-      "#55FFFFFF",
-      "#FF5555FF",
-      "#FF55FFFF",
-      "#FFFF55FF",
-      "#FFFFFFFF",
-    ]
-    colors.forEach(color =>
-      expect(
-        imageDoc.querySelectorAll(`rect[fill="${color}"]`).length
-      ).to.equal(16)
+    expectValidFrameMetadata(
+      metadataDataURI,
+      {
+        "#000000FF": 16,
+        "#0000AAFF": 16,
+        "#00AA00FF": 16,
+        "#00AAAAFF": 16,
+        "#AA0000FF": 16,
+        "#AA00AAFF": 16,
+        "#AA5500FF": 16,
+        "#AAAAAAFF": 16,
+        "#555555FF": 16,
+        "#5555FFFF": 16,
+        "#55FF55FF": 16,
+        "#55FFFFFF": 16,
+        "#FF5555FF": 16,
+        "#FF55FFFF": 16,
+        "#FFFF55FF": 16,
+        "#FFFFFFFF": 16
+      }
     );
 
     expect(await stunningPotato.tokenData(tokenId)).to.equal(frameData);
@@ -210,7 +285,12 @@ describe("StunningPotato", function () {
 
     // wait until the transaction is mined
     const createFrameRx = await createFrameTx.wait();
-    expect(createFrameRx.gasUsed.toString()).to.equal(GAS_COST_CREATE_FRAME_WITH_TRANSPARENCY);
+
+    if (TEST_GAS_COST) {
+      expect(createFrameRx.gasUsed.toString()).to.equal(
+        GAS_COST_CREATE_FRAME_WITH_TRANSPARENCY
+      );
+    }
 
     const transfer = (createFrameRx.events ?? []).find(
       event => event.event === "Transfer"
@@ -218,47 +298,26 @@ describe("StunningPotato", function () {
     const { tokenId } = transfer?.args ?? { tokenId: "" };
 
     const metadataDataURI = await stunningPotato.tokenURI(tokenId);
-    // Get data URI content
-    const metadataContent = metadataDataURI.split(",").pop();
-    if (metadataContent == null) {
-      throw "Unexpected empty metadata content";
-    }
-    const metadataDecoded = decodeURIComponent(metadataContent);
-    const metadata = JSON.parse(metadataDecoded);
-    expect(metadata.description).to.equal("Very expensive pixel art animations.");
-    const imageDataURI = metadata.image;
-    // Get data URI content
-    const imageContent = imageDataURI.split(",").pop();
-    if (imageContent == null) {
-      throw "Unexpected empty image content";
-    }
-    const image = decodeURIComponent(imageContent);
-    var imageDoc = new JSDOM(image).window.document;
-    expect(
-      imageDoc.getElementsByTagNameNS("http://www.w3.org/2000/svg", "rect").length
-    ).to.equal(256);
-    const colors = [
-      "#00000000", // Transparent color
-      "#0000AAFF",
-      "#00AA00FF",
-      "#00AAAAFF",
-      "#AA0000FF",
-      "#AA00AAFF",
-      "#AA5500FF",
-      "#AAAAAAFF",
-      "#555555FF",
-      "#5555FFFF",
-      "#55FF55FF",
-      "#55FFFFFF",
-      "#FF5555FF",
-      "#FF55FFFF",
-      "#FFFF55FF",
-      "#FFFFFFFF",
-    ]
-    colors.forEach(color =>
-      expect(
-        imageDoc.querySelectorAll(`rect[fill="${color}"]`).length
-      ).to.equal(16)
+    expectValidFrameMetadata(
+      metadataDataURI,
+      {
+        "#00000000": 16, // Transparent color
+        "#0000AAFF": 16,
+        "#00AA00FF": 16,
+        "#00AAAAFF": 16,
+        "#AA0000FF": 16,
+        "#AA00AAFF": 16,
+        "#AA5500FF": 16,
+        "#AAAAAAFF": 16,
+        "#555555FF": 16,
+        "#5555FFFF": 16,
+        "#55FF55FF": 16,
+        "#55FFFFFF": 16,
+        "#FF5555FF": 16,
+        "#FF55FFFF": 16,
+        "#FFFF55FF": 16,
+        "#FFFFFFFF": 16
+      }
     );
 
     expect(await stunningPotato.tokenData(tokenId)).to.equal(frameData);
@@ -304,7 +363,7 @@ describe("StunningPotato", function () {
   });
 
   it("Should create a new animation", async function () {
-    const frameData = `0x${"0".repeat(282)}`;
+    const frameData = testFrameData();
     const animationData = `0x0000${frameData.slice(2)}`;
     const createAnimationTx = await stunningPotato.createAnimation(
       addr1.address,
@@ -314,7 +373,12 @@ describe("StunningPotato", function () {
 
     // wait until the transaction is mined
     const createAnimationRx = await createAnimationTx.wait();
-    expect(createAnimationRx.gasUsed.toString()).to.equal(GAS_COST_CREATE_ANIMATION);
+
+    if (TEST_GAS_COST) {
+      expect(createAnimationRx.gasUsed.toString()).to.equal(
+        GAS_COST_CREATE_ANIMATION
+      );
+    }
 
     const [
       frameTokenTransfer,
@@ -325,18 +389,35 @@ describe("StunningPotato", function () {
     const { tokenId: frameId } = frameTokenTransfer.args ?? { tokenId: "" };
     const { tokenId: animationId } = animationTokenTransfer.args ?? { tokenId: "" };
 
-    // animation token is present
-    expect(
-      await stunningPotato.tokenURI(animationId)
-    ).to.equal(`https://ethga.xyz/t/${animationId}`);
+    const metadataDataURI = await stunningPotato.tokenURI(animationId);
+    expectValidAnimationMetadata(
+      metadataDataURI,
+      [{
+        "#000000FF": 16,
+        "#0000AAFF": 16,
+        "#00AA00FF": 16,
+        "#00AAAAFF": 16,
+        "#AA0000FF": 16,
+        "#AA00AAFF": 16,
+        "#AA5500FF": 16,
+        "#AAAAAAFF": 16,
+        "#555555FF": 16,
+        "#5555FFFF": 16,
+        "#55FF55FF": 16,
+        "#55FFFFFF": 16,
+        "#FF5555FF": 16,
+        "#FF55FFFF": 16,
+        "#FFFF55FF": 16,
+        "#FFFFFFFF": 16
+      }]
+    );
 
-    expect(await stunningPotato.tokenData(animationId)).to.equal(animationData);
+    // The contract stores just a reference to the frame instead of storing the
+    // raw frame data, that is already stored on-chain
+    const animationStorageData = `0x0000${frameId.toHexString().slice(2)}`;
+    expect(await stunningPotato.tokenData(animationId)).to.equal(animationStorageData);
 
     // frame token is present
-    expect(
-      await stunningPotato.tokenURI(frameId)
-    ).to.equal(`https://ethga.xyz/t/${frameId}`);
-
     expect(await stunningPotato.tokenData(frameId)).to.equal(frameData);
 
     const salePrice = 99;
@@ -349,7 +430,7 @@ describe("StunningPotato", function () {
   });
 
   it("Should create a new animation (largest animation possible)", async function () {
-    const frameData = `0x${"0".repeat(282)}`;
+    const frameData = testFrameData();
     const animationData = `0xf000${frameData.slice(2).repeat(16)}`;
     const createAnimationTx = await stunningPotato.createAnimation(
       addr1.address,
@@ -359,7 +440,12 @@ describe("StunningPotato", function () {
 
     // wait until the transaction is mined
     const createAnimationRx = await createAnimationTx.wait();
-    expect(createAnimationRx.gasUsed.toString()).to.equal(GAS_COST_CREATE_ANIMATION_LARGE);
+
+    if (TEST_GAS_COST) {
+      expect(createAnimationRx.gasUsed.toString()).to.equal(
+        GAS_COST_CREATE_ANIMATION_LARGE
+      );
+    }
 
     const [
       frameTokenTransfer,
@@ -370,18 +456,35 @@ describe("StunningPotato", function () {
     const { tokenId: frameId } = frameTokenTransfer.args ?? { tokenId: "" };
     const { tokenId: animationId } = animationTokenTransfer.args ?? { tokenId: "" };
 
-    // animation token is present
-    expect(
-      await stunningPotato.tokenURI(animationId)
-    ).to.equal(`https://ethga.xyz/t/${animationId}`);
+    const metadataDataURI = await stunningPotato.tokenURI(animationId);
+    expectValidAnimationMetadata(
+      metadataDataURI,
+      Array(16).fill({
+        "#000000FF": 16,
+        "#0000AAFF": 16,
+        "#00AA00FF": 16,
+        "#00AAAAFF": 16,
+        "#AA0000FF": 16,
+        "#AA00AAFF": 16,
+        "#AA5500FF": 16,
+        "#AAAAAAFF": 16,
+        "#555555FF": 16,
+        "#5555FFFF": 16,
+        "#55FF55FF": 16,
+        "#55FFFFFF": 16,
+        "#FF5555FF": 16,
+        "#FF55FFFF": 16,
+        "#FFFF55FF": 16,
+        "#FFFFFFFF": 16
+      })
+    );
 
-    expect(await stunningPotato.tokenData(animationId)).to.equal(animationData);
+    // The contract stores just a reference to the frame instead of storing the
+    // raw frame data, that is already stored on-chain
+    const animationStorageData = `0xf000${frameId.toHexString().slice(2).repeat(16)}`;
+    expect(await stunningPotato.tokenData(animationId)).to.equal(animationStorageData);
 
     // frame token is present
-    expect(
-      await stunningPotato.tokenURI(frameId)
-    ).to.equal(`https://ethga.xyz/t/${frameId}`);
-
     expect(await stunningPotato.tokenData(frameId)).to.equal(frameData);
 
     const salePrice = 99;

--- a/hardhat-project/test/index.ts
+++ b/hardhat-project/test/index.ts
@@ -7,8 +7,8 @@ import { JSDOM } from "jsdom";
 const TEST_GAS_COST = true;
 const GAS_COST_CREATE_FRAME = '313382';
 const GAS_COST_CREATE_FRAME_WITH_TRANSPARENCY = '313394';
-const GAS_COST_CREATE_ANIMATION = '541772';
-const GAS_COST_CREATE_ANIMATION_LARGE = '922375';
+const GAS_COST_CREATE_ANIMATION = '541703';
+const GAS_COST_CREATE_ANIMATION_LARGE = '920926';
 
 function encodeColorTable(...colors: number[]): string {
   return [0, 4, 8, 12].reduce(


### PR DESCRIPTION
Two main optimizations for animations:

1. Optimized storage memory layout using frame references instead of
   frame data
2. Inline assembly to copy frame bitmap data

## New animation storage data encoding

Animation storage data format is now different from the input
animation data format. The difference is that instead of storing the
raw data of each frame, the storage animation data stores just frame
ids.

The trade off is some time spent to compute the new format in
exchange for 141 - 32 = 109 spared bytes per frame.

```
$ npx hardhat size-contracts && npx hardhat test
Compiling 18 files with 0.8.4
Generating typings for: 17 artifacts in dir: typechain for target: ethers-v5
Successfully generated 27 typings!
Solidity compilation finished successfully
 ·------------------|-------------·
 |  Contract Name   ·  Size (KB)  │
 ···················|··············
 |  SVG             ·      0.086  │
 ···················|··············
 |  console         ·      0.086  │
 ···················|··············
 |  Address         ·      0.086  │
 ···················|··············
 |  Strings         ·      0.086  │
 ···················|··············
 |  ERC721          ·      5.168  │
 ···················|··············
 |  StunningPotato  ·     16.777  │
 ·------------------|-------------·
No need to generate any newer typings.

  StunningPotato
    ✓ Should create a new frame
    ✓ Should create a new frame with a trasparent color
    ✓ Should reject invalid frame data
    ✓ Should reject duplicate frames
    ✓ Should create a new animation
    ✓ Should create a new animation (largest animation possible)
    ✓ Should reject duplicate animations
    ✓ Should reject invalid animation data (too short)
    ✓ Should reject invalid animation data (frames count doesn't match)
    ✓ Should allow the owner to withdraw funds
    ✓ Should not allow non-owners to withdraw funds

·--------------------------------------|---------------------------|--------------|-----------------------------·
|         Solc version: 0.8.4          ·  Optimizer enabled: true  ·  Runs: 1000  ·  Block limit: 30000000 gas  │
·······································|···························|··············|······························
|  Methods                                                                                                      │
···················|···················|·············|·············|··············|···············|··············
|  Contract        ·  Method           ·  Min        ·  Max        ·  Avg         ·  # calls      ·  usd (avg)  │
···················|···················|·············|·············|··············|···············|··············
|  StunningPotato  ·  createAnimation  ·     440604  ·     922375  ·      634917  ·            6  ·          -  │
···················|···················|·············|·············|··············|···············|··············
|  StunningPotato  ·  createFrame      ·     212214  ·     313394  ·      249005  ·           11  ·          -  │
···················|···················|·············|·············|··············|···············|··············
|  StunningPotato  ·  withdraw         ·          -  ·          -  ·       30506  ·            1  ·          -  │
···················|···················|·············|·············|··············|···············|··············
|  Deployments                         ·                                          ·  % of limit   ·             │
·······································|·············|·············|··············|···············|··············
|  StunningPotato                      ·          -  ·          -  ·     3742246  ·       12.5 %  ·          -  │
·--------------------------------------|-------------|-------------|--------------|---------------|-------------·

  11 passing (27s)
```

## Note

In the test, compared to the older contract version, the absolute gas cost has increased by:

1. Single frame animation +23% (before: 440604, after: 541772)
2. 16 frames animation +16% (before: 796187, after: 922375)

That's due to the fact that I've changed the test data to use frames that are not all zeroes.

See #3 for more information about Gas savings brought by this optimization.

## References

* https://github.com/ethereum/solidity-examples/blob/master/src/bytes/Bytes.sol
* https://github.com/ethereum/solidity-examples/blob/master/docs/bytes/Bytes.md
* https://docs.soliditylang.org/en/v0.8.12/internals/layout_in_storage.html#layout-of-state-variables-in-storage
* https://github.com/ethereum/solidity-examples/blob/master/src/unsafe/Memory.sol
* https://docs.soliditylang.org/en/v0.8.12/yul.html
* https://docs.soliditylang.org/en/v0.8.12/assembly.html
* https://github.com/OpenZeppelin/solidity-jwt/blob/master/contracts/Base64.sol
* https://docs.soliditylang.org/en/v0.8.12/abi-spec.html#non-standard-packed-mode
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
* https://medium.com/@hayeah/diving-into-the-ethereum-vm-the-hidden-costs-of-arrays-28e119f04a9b